### PR TITLE
Add page for creation of non-Python test libraries

### DIFF
--- a/website/docs/extending_robot_framework/custom-libraries/non-python_library.md
+++ b/website/docs/extending_robot_framework/custom-libraries/non-python_library.md
@@ -1,0 +1,70 @@
+---
+sidebar_position: 0
+sidebar_label: Create Non-Python Libraries
+title: Non-Python Libraries
+---
+
+### Rust
+
+Create a dynamic system library (crate_type = "cdylib") from the following source code.
+
+```rust
+#![allow(non_snake_case)]
+
+use std::collections::HashMap;
+
+use pyo3::prelude::*;
+
+#[pyfunction]
+fn sum_as_string(a: i32, b: i32) -> PyResult<String> {
+    Ok((a + b).to_string())
+}
+
+#[pyfunction]
+fn join_strings(a: Vec<String>) -> PyResult<String> {
+    Ok(a.join(","))
+}
+
+#[pyfunction]
+fn sum_values(a: HashMap<String, i32>) -> PyResult<i32> {
+    let mut values_sum = 0;
+    for (_key, value) in &a {
+        values_sum += value;
+    }
+    Ok(values_sum)
+}
+
+#[pymodule]
+fn RustyLibrary(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
+    m.add_function(wrap_pyfunction!(join_strings, m)?)?;
+    m.add_function(wrap_pyfunction!(sum_values, m)?)?;
+    Ok(())
+}
+```
+
+The library can then be used as follows.
+
+```robotframework
+*** Settings ***
+Library    RustyLibrary
+
+*** Test Cases ***
+Integer Argument Conversion Test
+    ${x} =    Sum As String    ${5}    ${20}
+    Should Be Equal    ${x}    25
+
+List Argument Conversion Test
+    @{MY_LIST} =    Create List    spam    eggs
+
+    ${y} =    Join Strings    ${MY_LIST}
+    Should Be Equal    ${y}    spam,eggs
+
+Dictionary Argument Conversion Test
+    &{MY_DICT} =    Create Dictionary    spam    ${11}    eggs    ${22}
+
+    ${z} =    Sum Values    ${MY_DICT}
+    Should Be Equal    ${z}    ${33}
+```
+
+A complete working example that includes all build files (e.g. Cargo.toml) can be found on [GitHub / mneiferbag / robot-python-test-library](https://github.com/mneiferbag/robot-rust-test-library).


### PR DESCRIPTION
A first proposal. I've made the page somewhat similar to the page that describes test libraries implemented in Python: 1. show the source code for the library, 2. show the keyword use in RF. However, for languages other than Python, just giving the source code for the library does not always provide a full example. For example, to build the Rust code, a build file "Cargo.toml" is needed. To address this, I have included a link to a GitHub repository with a complete working example with all needed files. Please let me know what you think about this.

The Rust source has no syntax highlighting. I have no idea how to fix this.

Note: I'm not a native speaker of English. Feel free to make notes about spelling, grammar and punctuation. 😄 