### PR TITLE
Fixed broken links through PR on Style Guide repo

### DIFF
--- a/website/docs/style_guide.md
+++ b/website/docs/style_guide.md
@@ -719,11 +719,11 @@ My Nested Keyword
 
 #### Line Length
 
-> A line length of 120 characters is recommended. [Robocop: #line-too-long](https://robocop.readthedocs.io/en/stable/rules.html#line-too-long)
+> A line length of 120 characters is recommended. [Robocop: #line-too-long](https://robocop.readthedocs.io/en/stable/rules_list.html#line-too-long-w0508)
 
 #### Trailing Whitespaces
 
-> Trailing whitespaces should be avoided. [Robocop: #trailing-whitespace](https://robocop.readthedocs.io/en/stable/rules.html#trailing-whitespace)
+> Trailing whitespaces should be avoided. [Robocop: #trailing-whitespace](https://robocop.readthedocs.io/en/stable/rules_list.html#trailing-whitespace-w1001)
 
 ---
 
@@ -733,7 +733,7 @@ My Nested Keyword
 
 Indentations should only be added when needed.
 
-The `*** Settings ***` section should always be left aligned without any indentation [Robocop: #suite-setting-should-be-left-aligned](https://robocop.readthedocs.io/en/stable/rules.html#suite-setting-should-be-left-aligned)
+The `*** Settings ***` section should always be left aligned without any indentation [Robocop: #suite-setting-should-be-left-aligned](https://robocop.readthedocs.io/en/stable/rules_list.html#suite-setting-should-be-left-aligned-e1016)
 
 ```robot
 *** Settings ***
@@ -782,7 +782,7 @@ Test Tags     mytag
 
 #### Indentation Within Variables Section
 
-The `*** Variables ***` section should always be left aligned without any indentation [Robocop: #variable-should-be-left-aligned](https://robocop.readthedocs.io/en/stable/rules.html#variable-should-be-left-aligned)
+The `*** Variables ***` section should always be left aligned without any indentation [Robocop: #variable-should-be-left-aligned](https://robocop.readthedocs.io/en/stable/rules_list.html#variable-should-be-left-aligned-e1014)
 
 ```robot
 *** Variables ***
@@ -833,7 +833,7 @@ Test Step Two That Returns A Value
 
 #### Block Indentation
 
-Blocks like `IF`, `WHILE`, `FOR` and `TRY/EXCEPT` should always be indented such that the keywords that are run within the loop have to be indented from the lines that start and end the block. [Robocop: #bad-indent](https://robocop.readthedocs.io/en/stable/rules.html#bad-indent)
+Blocks like `IF`, `WHILE`, `FOR` and `TRY/EXCEPT` should always be indented such that the keywords that are run within the loop have to be indented from the lines that start and end the block. [Robocop: #bad-indent](https://robocop.readthedocs.io/en/stable/rules_list.html#bad-indent-w1008)
 
 #### Examples From The User Guide
 
@@ -898,7 +898,7 @@ First example
 
 ### Comments
 
-In comments there should be a space between the `#` and the actual comment. [Robocop: #missing-space-after-comment](https://robocop.readthedocs.io/en/stable/rules.html#missing-space-after-comment)
+In comments there should be a space between the `#` and the actual comment. [Robocop: #missing-space-after-comment](https://robocop.readthedocs.io/en/stable/rules_list.html#missing-space-after-comment-w0702)
 
 Comments should be avoided, write your code readable or use the `[Documentation]`.
 The only valid use of comments is for TODO's that should be fixed soon.

--- a/website/docs/style_guide.md
+++ b/website/docs/style_guide.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Style Guide
 
-Version 0.8b
+Version 0.9b
 
 ## Introduction
 


### PR DESCRIPTION
Fixing broken links to new documentation Robocop

As per PR from @kkotenko
https://github.com/MarketSquare/robotframework-style-guide/pull/59