### PR TITLE
PyCharm obsolete and broken links fix for getting_started/ide.mdx

### DIFF
--- a/website/docs/getting_started/ide.mdx
+++ b/website/docs/getting_started/ide.mdx
@@ -131,11 +131,11 @@ Popular extensions for Robot Framework:
 
 #### Install PyCharm
 
-See the [PyCharm installation instructions](https://www.jetbrains.com/help/pycharm/2021.3/installation-guide.html) for more information.
+See the [PyCharm installation instructions](https://www.jetbrains.com/help/pycharm/installation-guide.html) for more information.
 
 There two installation approaches
-- The recommended one by JetBrains using the [Toolbox App](https://www.jetbrains.com/help/toolbox/app/installation.html).
-- The alternative [stand alone installation](https://www.jetbrains.com/help/pycharm/2021.3/installation-guide.html#standalone)
+- The recommended one by JetBrains using the [Toolbox App](https://www.jetbrains.com/toolbox-app).
+- The alternative [stand alone installation](https://www.jetbrains.com/help/pycharm/installation-guide.html#standalone)
 
 Make sure to install the free `PyCharm Community Edition` and not the `PyCharm Professional` version.
 


### PR DESCRIPTION
  PyCharm help links without pointing particular version leads to actual one, and there is no more help section for Toolbox.
- https://www.jetbrains.com/help/pycharm/installation-guide.html
- https://www.jetbrains.com/toolbox-app
- https://www.jetbrains.com/help/pycharm/installation-guide.html#standalone