### PR TITLE
update: updating RF version installation

### DIFF
--- a/code-examples/core/bdd-syntax/config.json
+++ b/code-examples/core/bdd-syntax/config.json
@@ -2,7 +2,7 @@
     "name": "BDD Syntax",
     "description": "readme.md",
     "requirements": [
-        "robotframework==6.0",
+        "robotframework==7.0",
         "robotframework-stacktrace",
         "robotframework-retryfailed"
     ],


### PR DESCRIPTION
example code was throwing an error message about an already depricated version of RF:
```
Initializing...
Install Robot Framework
Traceback (most recent call last):
  File "<exec>", line 31, in <module>
  File "/lib/python3.10/site-packages/micropip/_micropip.py", line 573, in install
    await transaction.gather_requirements(requirements)
  File "/lib/python3.10/site-packages/micropip/_micropip.py", line 333, in gather_requirements
    await gather(*requirement_promises)
  File "/lib/python3.10/asyncio/futures.py", line 284, in __await__
    yield self  # This tells Task to wait for completion.
  File "/lib/python3.10/asyncio/tasks.py", line 304, in __wakeup
    future.result()
  File "/lib/python3.10/asyncio/futures.py", line 201, in result
    raise self._exception
  File "/lib/python3.10/asyncio/tasks.py", line 232, in __step
    result = coro.send(None)
  File "/lib/python3.10/site-packages/micropip/_micropip.py", line 340, in add_requirement
    return await self.add_requirement_inner(Requirement(req))
  File "/lib/python3.10/site-packages/micropip/_micropip.py", line 443, in add_requirement_inner
    if self.check_version_satisfied(req):
  File "/lib/python3.10/site-packages/micropip/_micropip.py", line 364, in check_version_satisfied
    raise ValueError(
ValueError: Requested 'robotframework==6.0', but robotframework==7.0 is already installed
```