### PR TITLE
Update style_guide.md

### DIFF
--- a/website/docs/style_guide.md
+++ b/website/docs/style_guide.md
@@ -1148,7 +1148,7 @@ ${LONG ITEM}    some very long name of the
 ...             grape
 ...             avocado
 ...             kiwi
-...             $(LONG ITEM)
+...             ${LONG ITEM}
 ```
 
 ###### Dictionaries


### PR DESCRIPTION
In the Lists section, there is an example to demonstrate how to use the Long item in the list. one long item variable is added as the last element but the syntax should be ${LONG ITEM} but it is $(LONG ITEM) which doesn't expand to the value that LONG ITEM variable stores.

TL:DR;

Corrected the variable reference syntax. 