### PR TITLE
Update gitlab.md - fix Gitlab CI variable link

### DIFF
--- a/website/docs/using_rf_in_ci_systems/ci/gitlab.md
+++ b/website/docs/using_rf_in_ci_systems/ci/gitlab.md
@@ -130,4 +130,4 @@ It is possible to define variables in the configuration, either at the top of th
 Also [predefined GitLab variables](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html) or variables defined for your project settings can be used.  
 Especially for handling secrets, it is recommended to use `CI Variables` in your project settings.  
 
-Check out the [GitLab CI Variables](https://docs.gitlab.com/ee/ci/variables/README.html) documentation for more information.  
+Check out the [GitLab CI Variables](https://docs.gitlab.com/ee/ci/variables/) documentation for more information.  


### PR DESCRIPTION
the link to the Readme.html was changed, now it points to the correct section (without the specific html)