### PR TITLE
Metrics Report: Broken Link Update

### DIFF
--- a/website/docs/reporting_alternatives.md
+++ b/website/docs/reporting_alternatives.md
@@ -39,4 +39,5 @@ https://www.eficode.com/blog/rf-jenkins-grafana
 
 [Robot Framework Metrics](https://github.com/adiralashiva8/robotframework-metrics) creates custom HTML report (dashboard view) by parsing robotframework output.xml file
 
- - __Sample Report__ [link](https://rfmetrics.netlify.com/)
+Images
+![Metrics Report](https://adiralashiva8.github.io/robotframework-metrics/metrics.png)


### PR DESCRIPTION
* Replace broken link with image URL of metrics report (image hosted using github pages)
https://github.com/MarketSquare/robotframeworkguides/issues/51 will be fixed with this change