### PR TITLE
Update official Allure Report website and add additional link to the docs

### DIFF
--- a/website/docs/reporting_alternatives.md
+++ b/website/docs/reporting_alternatives.md
@@ -15,9 +15,9 @@ It is integrated with Robot Framework via a listener [robotframework-reportporta
 
 
 ### Allure
-[Allure Framework](https://docs.qameta.io/allure-report/) is a flexible lightweight multi-language test report tool that not only shows a very concise representation of what have been tested in a neat web report form, but allows everyone participating in the development process to extract maximum of useful information from everyday execution of tests.
+[Allure Report](https://allurereport.org/) is a flexible lightweight multi-language test report tool that not only shows a very concise representation of what have been tested in a neat web report form, but allows everyone participating in the development process to extract maximum of useful information from everyday execution of tests.
 
-It is integrated with Robot Framework via a listener [robotframework-allure](https://github.com/allure-framework/allure-python)
+It is integrated with Robot Framework via a listener [robotframework-allure](https://github.com/allure-framework/allure-python). A detailed integration guide is available on the official website: https://allurereport.org/docs/robotframework/
 
 ### Grafana
 Grafana can be used to visualize test results in a dashboard.  


### PR DESCRIPTION
The Allure Report website has recently been changed to https://allurereport.org. You can validate it by reviewing https://github.com/allure-framework  (note the [verified badge](https://docs.github.com/en/organizations/managing-organization-settings/verifying-or-approving-a-domain-for-your-organization)).

I also added a link to the official Robotframework integration guide.