### PR TITLE
Add link to DatabaseLibrary's keyword documentation.

### DIFF
--- a/website/docs/different_libraries/database.md
+++ b/website/docs/different_libraries/database.md
@@ -9,6 +9,7 @@ It offers keywords to e.g.
 - execute SQL queries
 - fetch results from the database
 - assert table contents and result sets
+
 For specifics, please refer to the library's [Keyword documentation](https://marketsquare.github.io/Robotframework-Database-Library/#library-documentation-top).
 
 ## Installation


### PR DESCRIPTION
I have often looked for that link from this page but to no avail. I believe it will be useful for others, too.