### PR TITLE
${FALSE} instead of false in boolean

### DIFF
--- a/website/static/code-examples/requests/restful_booker.robot
+++ b/website/static/code-examples/requests/restful_booker.robot
@@ -20,7 +20,7 @@ Get Bookings from Restful Booker
 
 Create a Booking at Restful Booker
     ${booking_dates}    Create Dictionary    checkin=2022-12-31    checkout=2023-01-01
-    ${body}    Create Dictionary    firstname=Hans    lastname=Gruber    totalprice=200    depositpaid=false    bookingdates=${booking_dates}
+    ${body}    Create Dictionary    firstname=Hans    lastname=Gruber    totalprice=200    depositpaid=${FALSE}    bookingdates=${booking_dates}
     ${response}    POST    url=https://restful-booker.herokuapp.com/booking    json=${body}
     ${id}    Set Variable    ${response.json()}[bookingid]
     Set Suite Variable    ${id}


### PR DESCRIPTION
Currently, if you use the text false here as a Boolean value, the string "false" will be included in the request, but you'll find it as a true in the response because the restful-booker's JavaScript parses any non-empty string as true boolean value. So the false becoming true.
With the built in ${FALSE} variable it works well.

It may seem like a small thing, but it can really confuse a new user when something doesn't work for them even though they followed the instructions from the documentation.